### PR TITLE
Add build script for hosted live site

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{css,html,js,ts,tsx,xml,json}]
+indent_style = space
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:22
 
-RUN apt update && \
-    apt install -y vim tmux nginx git && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /usr/src/app
 
 COPY . ./
@@ -13,9 +9,3 @@ RUN cd ./3dparty/cesium-img-selector && \
 
 RUN cd /usr/src/app && \
     yarn && yarn build
-
-COPY docker/default.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-
-STOPSIGNAL SIGTERM
-CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Visual editor for KML and CZML documents
 
 https://www.visionport.com/cesium-kml-czml-editor/
+
+## Building
+
+Running `bin/build` will build the site and copy it to the `dist` directory. You can then serve that directory statically.
+
+This script automatically deletes the container, but *not* the image. You can also recreate the app without rebuilding the image by passing the `-r` flag.

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+Help() {
+  echo "Usage: build [-r]"
+  echo ""
+	echo "-r           recreate container without rebuilding image"
+}
+
+set -euo pipefail
+trap 'exit 1' INT
+
+run_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )
+cd "$run_dir"/.. || exit 1
+
+NO_BUILD=
+
+while getopts ":rh" option; do
+  case $option in
+    h) # Show help
+      Help
+	  exit;;
+    r) # Recreate the same image instead of building a new one
+      NO_BUILD=true
+    ;;
+  esac
+done
+
+DIST_DIR=/home/visionport/live/external/czml-editor/dist/
+
+[[ -z "$NO_BUILD" ]] && podman build -t czml-editor .
+
+# Create a temporary container from the image
+CONTAINER_ID=$(podman create czml-editor)
+
+# Copy the files from the container to your host machine
+mkdir -p tmp
+podman cp $CONTAINER_ID:/usr/src/app/dist tmp
+rm -rf $DIST_DIR && mv tmp/dist $DIST_DIR
+
+# Remove the temporary container
+podman rm $CONTAINER_ID

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cesium CZML editor</title>
     <script src="/customizations.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TTQQK3B89Z"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
This also removes nginx from the docker container, which is needed for production. Once you build using the script, it puts the generated files in the `dist/` directory, which you can easily serve for development using `python3 -m http.server` or even nginx locally. @kiselev-dv thoughts?